### PR TITLE
Show breeding history only when breeding data exists

### DIFF
--- a/client/pages/AnimalTracker.tsx
+++ b/client/pages/AnimalTracker.tsx
@@ -86,6 +86,8 @@ export default function AnimalTracker() {
   const [editingAnimal, setEditingAnimal] = useState<AnimalRecord | null>(null);
   const [viewingAnimal, setViewingAnimal] = useState<AnimalRecord | null>(null);
   const [isHealthSectionExpanded, setIsHealthSectionExpanded] = useState(true);
+  const [hasBreedingData, setHasBreedingData] = useState(false);
+  const [breedingLoading, setBreedingLoading] = useState(true);
   const { toast } = useToast();
 
   // Pagination for filtered animals
@@ -95,13 +97,15 @@ export default function AnimalTracker() {
   useEffect(() => {
     const loadData = async () => {
       try {
-        const [animalsData, summaryData] = await Promise.all([
+        const [animalsData, summaryData, breedingRecords] = await Promise.all([
           animalApi.fetchAnimals(),
           animalApi.fetchAnimalSummary(),
+          animalApi.fetchBreedingRecords(),
         ]);
         setAnimals(animalsData);
         setFilteredAnimals(animalsData);
         setSummary(summaryData);
+        setHasBreedingData(breedingRecords.length > 0);
       } catch (error) {
         console.error("Error loading animal data:", error);
         toast({
@@ -111,6 +115,7 @@ export default function AnimalTracker() {
         });
       } finally {
         setLoading(false);
+        setBreedingLoading(false);
       }
     };
     loadData();
@@ -503,15 +508,17 @@ export default function AnimalTracker() {
 
                 <BulkHealthRecordsManager animals={animals} />
 
-                <Link to="/breeding-history">
-                  <Button
-                    variant="outline"
-                    className="bg-pink-50 border-pink-200 text-pink-700 hover:bg-pink-100"
-                  >
-                    <Baby className="h-4 w-4 mr-2" />
-                    Breeding History
-                  </Button>
-                </Link>
+                {hasBreedingData && !breedingLoading && (
+                  <Link to="/breeding-history">
+                    <Button
+                      variant="outline"
+                      className="bg-pink-50 border-pink-200 text-pink-700 hover:bg-pink-100"
+                    >
+                      <Baby className="h-4 w-4 mr-2" />
+                      Breeding History
+                    </Button>
+                  </Link>
+                )}
 
                 <ExportCSVButton
                   data={filteredAnimals}

--- a/client/pages/MainPage.tsx
+++ b/client/pages/MainPage.tsx
@@ -28,7 +28,11 @@ import {
 import { ExpenseRecord } from "@shared/expense-types";
 import * as api from "@/lib/api";
 import { Task, fetchTasks } from "@/lib/task-api";
-import { AnimalRecord, fetchAnimals, fetchBreedingRecords } from "@/lib/animal-api";
+import {
+  AnimalRecord,
+  fetchAnimals,
+  fetchBreedingRecords,
+} from "@/lib/animal-api";
 import { getApiConfig } from "@/lib/api-config";
 
 export default function MainPage() {
@@ -532,16 +536,18 @@ export default function MainPage() {
                         ? `${animalStats.totalAnimals} active animals (excluding sold/dead)`
                         : "No animals found - add your first livestock!"}
                     </span>
-                    {animalStats.totalAnimals > 0 && hasBreedingData && !breedingLoading && (
-                      <div className="mt-2">
-                        <Link
-                          to="/breeding-history"
-                          className="text-xs text-pink-600 hover:text-pink-700 underline font-medium"
-                        >
-                          📋 View Breeding History
-                        </Link>
-                      </div>
-                    )}
+                    {animalStats.totalAnimals > 0 &&
+                      hasBreedingData &&
+                      !breedingLoading && (
+                        <div className="mt-2">
+                          <Link
+                            to="/breeding-history"
+                            className="text-xs text-pink-600 hover:text-pink-700 underline font-medium"
+                          >
+                            📋 View Breeding History
+                          </Link>
+                        </div>
+                      )}
                   </div>
                 </div>
               )}

--- a/client/pages/MainPage.tsx
+++ b/client/pages/MainPage.tsx
@@ -28,16 +28,18 @@ import {
 import { ExpenseRecord } from "@shared/expense-types";
 import * as api from "@/lib/api";
 import { Task, fetchTasks } from "@/lib/task-api";
-import { AnimalRecord, fetchAnimals } from "@/lib/animal-api";
+import { AnimalRecord, fetchAnimals, fetchBreedingRecords } from "@/lib/animal-api";
 import { getApiConfig } from "@/lib/api-config";
 
 export default function MainPage() {
   const [expenses, setExpenses] = useState<ExpenseRecord[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [animals, setAnimals] = useState<AnimalRecord[]>([]);
+  const [hasBreedingData, setHasBreedingData] = useState(false);
   const [loading, setLoading] = useState(true);
   const [tasksLoading, setTasksLoading] = useState(true);
   const [animalsLoading, setAnimalsLoading] = useState(true);
+  const [breedingLoading, setBreedingLoading] = useState(true);
   const [stats, setStats] = useState({
     totalIncome: 0,
     totalExpenses: 0,
@@ -153,9 +155,22 @@ export default function MainPage() {
       }
     };
 
+    const loadBreedingData = async () => {
+      try {
+        const breedingRecords = await fetchBreedingRecords();
+        setHasBreedingData(breedingRecords.length > 0);
+      } catch (error) {
+        console.error("Error loading breeding data:", error);
+        setHasBreedingData(false);
+      } finally {
+        setBreedingLoading(false);
+      }
+    };
+
     loadStats();
     loadTasks();
     loadAnimals();
+    loadBreedingData();
   }, []);
 
   const formatCurrency = (amount: number) => {
@@ -517,7 +532,7 @@ export default function MainPage() {
                         ? `${animalStats.totalAnimals} active animals (excluding sold/dead)`
                         : "No animals found - add your first livestock!"}
                     </span>
-                    {animalStats.totalAnimals > 0 && (
+                    {animalStats.totalAnimals > 0 && hasBreedingData && !breedingLoading && (
                       <div className="mt-2">
                         <Link
                           to="/breeding-history"


### PR DESCRIPTION
## Purpose

The user requested to show the "Breeding History" section in the main page and animal tracker only when breeding data is actually available. This improves the user experience by hiding irrelevant navigation options when no breeding records exist.

## Code changes

- Added `hasBreedingData` and `breedingLoading` state variables to track breeding data availability
- Modified data loading to fetch breeding records and check if any exist
- Wrapped breeding history buttons/links with conditional rendering based on `hasBreedingData` and loading state
- Applied changes to both MainPage.tsx and AnimalTracker.tsx components
- Added proper loading states to prevent flickering during data fetch

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fbbfd235a3b944079c4ce98661582d21/orbit-garden)

👀 [Preview Link](https://fbbfd235a3b944079c4ce98661582d21-orbit-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fbbfd235a3b944079c4ce98661582d21</projectId>-->
<!--<branchName>orbit-garden</branchName>-->