### PR TITLE
Add pagination to Health Records Overview component

### DIFF
--- a/client/components/HealthRecordsOverview.tsx
+++ b/client/components/HealthRecordsOverview.tsx
@@ -209,6 +209,19 @@ export default function HealthRecordsOverview({
 
   const stats = getHealthStats();
 
+  // Pagination for health records
+  const {
+    data: paginatedRecords,
+    pagination,
+    hasNextPage,
+    hasPreviousPage,
+    totalPages,
+    goToPage,
+    goToNextPage,
+    goToPreviousPage,
+    changePageSize,
+  } = usePagination(filteredRecords, 10);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center p-8">

--- a/client/components/HealthRecordsOverview.tsx
+++ b/client/components/HealthRecordsOverview.tsx
@@ -383,9 +383,9 @@ export default function HealthRecordsOverview({
               </p>
             </div>
           ) : (
-            <ScrollArea className="h-96">
-              <div className="space-y-4 pr-3">
-                {filteredRecords.map((record) => {
+            <>
+              <div className="space-y-4 mb-6">
+                {paginatedRecords.map((record) => {
                   const typeInfo = getRecordTypeInfo(record.recordType);
                   const TypeIcon = typeInfo.icon;
 
@@ -500,7 +500,20 @@ export default function HealthRecordsOverview({
                   );
                 })}
               </div>
-            </ScrollArea>
+
+              {/* Pagination Controls */}
+              {filteredRecords.length > 0 && (
+                <Pagination
+                  currentPage={pagination.page}
+                  totalPages={totalPages}
+                  totalItems={pagination.total}
+                  pageSize={pagination.pageSize}
+                  onPageChange={goToPage}
+                  onPageSizeChange={changePageSize}
+                  pageSizeOptions={[5, 10, 20, 50]}
+                />
+              )}
+            </>
           )}
         </CardContent>
       </Card>

--- a/client/components/HealthRecordsOverview.tsx
+++ b/client/components/HealthRecordsOverview.tsx
@@ -34,6 +34,8 @@ import {
 import { AnimalRecord, HealthRecord } from "@shared/animal-types";
 import * as animalApi from "@/lib/animal-api";
 import { useToast } from "@/hooks/use-toast";
+import { usePagination } from "@/hooks/use-pagination";
+import { Pagination } from "@/components/ui/pagination";
 
 interface HealthRecordsOverviewProps {
   animals: AnimalRecord[];


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR adds pagination functionality to the Health Records Overview to improve performance and user experience when viewing large sets of health records. The user specifically requested paging to be added to the Health Records Overview component.

## Code changes

- **Added pagination imports**: Imported `usePagination` hook and `Pagination` component
- **Implemented pagination logic**: Added pagination state management with configurable page size (default 10 records per page)
- **Updated UI structure**: 
  - Replaced `ScrollArea` with paginated display
  - Changed `filteredRecords` to `paginatedRecords` for rendering
  - Added pagination controls at the bottom of the records list
- **Enhanced user controls**: Added pagination component with page size options (5, 10, 20, 50) and navigation controls
- **Conditional rendering**: Pagination controls only show when there are filtered records to display

The implementation maintains all existing functionality while adding efficient pagination to handle large datasets.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/66578787b1c24154882935ab3bc57411/zenith-works)

👀 [Preview Link](https://66578787b1c24154882935ab3bc57411-zenith-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>66578787b1c24154882935ab3bc57411</projectId>-->
<!--<branchName>zenith-works</branchName>-->